### PR TITLE
Increase xdebug max function nesting level.

### DIFF
--- a/php/xdebug.ini
+++ b/php/xdebug.ini
@@ -122,7 +122,7 @@ xdebug.manual_url=http://www.php.net
 ; Controls the protection mechanism for infinite recursion protection. The value
 ; of this setting is the maximum level of nested functions that are allowed before
 ; the script will be aborted.
-xdebug.max_nesting_level=100
+xdebug.max_nesting_level=512
 
 ; Introduced in Xdebug 2.1
 ; By default Xdebug overloads var_dump() with its own improved version for displaying


### PR DESCRIPTION
Can't run PHPUnit without it.
512 is arbitrary.
