### PR TITLE
share authentication, but do not leak secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ let g:vdebug_options= {
 \}
 ```
 
+The recommended way to login to this container is to exec the login command on
+it, like this:
+
+```shell
+docker exec --interactive --tty samplesymfonyapp_appserver_1 /bin/login -p -f `whoami`
+```
+
+The `-p` flag tells login to preserve the environment, which contains
+`SSH_AUTH_SOCK`, used when authenticating against remove service that provide
+composer packages. The `-f` flag will allow us to bypass authentication.
+
 ### The mailcatcher container
 
 Exposes an administation interface on port 1080, and an SMTP service listening

--- a/dockeronify/templates/default/src/docker-compose.yml
+++ b/dockeronify/templates/default/src/docker-compose.yml
@@ -6,7 +6,7 @@ data:
         - .:/srv
         - ./docker/conf/nginx_vhost.conf:/etc/nginx/sites-enabled/my_app.conf
         - ~/.bashrc.docker:/home/developer/.bashrc
-        - ~/.ssh:/home/developer/.ssh
+        - $SSH_AUTH_SOCK:/tmp/agent.sock
 
 webserver:
     build: ./docker/docker-images/nginx
@@ -33,6 +33,7 @@ appserver:
         - ./docker-compose.env
     environment:
         - DNSDOCK_IMAGE=app
+        - SSH_AUTH_SOCK=/tmp/agent.sock
 
 database:
     build: ./docker/docker-images/postgres

--- a/sample_symfony_app/bashrc.docker
+++ b/sample_symfony_app/bashrc.docker
@@ -1,11 +1,1 @@
-if [ -d "/home/developer/.ssh" ]; then
-
-    # start ssh-agent and setup environment
-    _plugin__ssh_env=/home/developer/.ssh/environment-docker
-    ssh-agent | sed 's/^echo/#echo/' > ${_plugin__ssh_env}
-    chmod 600 ${_plugin__ssh_env}
-    . ${_plugin__ssh_env} > /dev/null
-
-fi
-
 cd /srv


### PR DESCRIPTION
By sharing the ssh authentication socket with the container, we are able
to authenticate with package providers just like we would from the host,
without sharing sensible files with the guest. I lost my ssh keys in the
battle, so this should probably not be taken lightly.
