### PR TITLE
compile locale definition files

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -14,6 +14,11 @@ RUN apt-get update && \
 	&& chmod +x /usr/local/bin/gosu \
 	&& apt-get purge -y --auto-remove curl
 
+RUN apt-get update && apt-get install --yes locales &&\
+	rm --recursive --force /var/lib/apt/lists/* && \
+	localedef --inputfile=en_US --force --charmap=UTF-8 --alias-file /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG en_US.utf8
 RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.3/main/pg_hba.conf
 RUN echo "listen_addresses='*'" >> /etc/postgresql/9.3/main/postgresql.conf
 


### PR DESCRIPTION
fixes #27

To upgrade, one needs to delete their data container (because the data container hold the postgres data directory). This can be done with this command : `docker-compose rm data`. Next, you need to rebuild the postgres image : `docker-compose build`.
