### PR TITLE
Disable the module xdebug

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ let g:vdebug_options= {
 \}
 ```
 
+By default, XDebug is disabled on the console container for performance
+reasons. It can be enabled by using php's `-d` flag, like this :
+
+```shell
+php -dzend_extension=xdebug.so <your_command_goes_here>
+```
+
 The recommended way to login to the console container is to exec the login
 command on it, like this:
 

--- a/php-console/Dockerfile
+++ b/php-console/Dockerfile
@@ -18,6 +18,8 @@ RUN curl --silent --show-error https://getcomposer.org/installer | php && \
 
 ADD php-cli.ini /etc/php5/cli/conf.d/30-dockerony.ini
 
+RUN php5dismod xdebug
+
 VOLUME /home/developer
 
 COPY entrypoint.sh /


### PR DESCRIPTION
To use this module with PHP use this command :

```
php -dzend_extension=xdebug.so {your_php_script.php}
```
