### PR TITLE
Replace ubuntu:trusty with tianon/true

### DIFF
--- a/dockeronify/templates/default/src/docker-compose.yml
+++ b/dockeronify/templates/default/src/docker-compose.yml
@@ -1,7 +1,7 @@
 # This container is specific to the application.
 # It contains configuration and data for other containers.
 data:
-    image: ubuntu:trusty
+    image: tianon/true
     volumes:
         - .:/srv
         - ./docker/conf/nginx_vhost.conf:/etc/nginx/sites-enabled/my_app.conf


### PR DESCRIPTION
Not necessary to download ubuntu just for share volumes
