### PR TITLE
Dns dock version

### DIFF
--- a/bin/docker-init
+++ b/bin/docker-init
@@ -13,6 +13,6 @@ then
     docker start dns_dock
 else
     docker run --detach=true --volume=/var/run/docker.sock:/var/run/docker.sock \
-        --publish=172.17.0.1:53:53/udp --name dns_dock tonistiigi/dnsdock
+        --publish=172.18.0.1:53:53/udp --name $dnsdockname tonistiigi/dnsdock:amd64-1.13.1
 fi
 

--- a/bin/docker-outline-dns
+++ b/bin/docker-outline-dns
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Get docker ip
+docker_ip=$(ip -family inet -oneline addr show docker0|\
+    cut --delimiter=' '  --fields=7|cut --delimiter='/' --fields=1)
+
+# Add dns as nameserver
+resolvconf -u
+sed --in-place "1i options timeout:1\nnameserver ${docker_ip}" /run/resolvconf/resolv.conf


### PR DESCRIPTION
With docker-compose write in version 2 and dnsdock:latest, the system is not working. Dnsdock:latest do not recognonize container IP. We have to use the "amd64-1.13.1" version (5 months younger) to fix it.